### PR TITLE
Dynamically import compression module in compressors.py

### DIFF
--- a/compressors.py
+++ b/compressors.py
@@ -1,27 +1,16 @@
 # Compressor Framework
-import gzip
-import bz2
-import lzma
-# from PIL.PngImagePlugin import getchunks
-# from PIL import Image
 import sys
+from importlib import import_module
 from tqdm import tqdm
 import torch.nn.functional as F
-
-
 import io
-
 
 class DefaultCompressor:
     """for non-neural-based compressor"""
     def __init__(self, compressor, typ='text'):
-        if compressor == 'gzip':
-            self.compressor = gzip
-        elif compressor == 'bz2':
-            self.compressor = bz2
-        elif compressor == 'lzma':
-            self.compressor = lzma
-        else:
+        try:
+            self.compressor = import_module(compressor)
+        except ImportError:
             raise RuntimeError("Unsupported compressor")
         self.type = typ
     def get_compressed_len(self, x):
@@ -38,5 +27,6 @@ class DefaultCompressor:
 
 
 """Test Compressors"""
-# comp = DefaultCompressor('gzip')
-# print(comp.get_compressed_len('Hello world'))
+if __name__ == '__main__':
+    comp = DefaultCompressor('gzip')
+    print(comp.get_compressed_len('Hello world'))

--- a/compressors.py
+++ b/compressors.py
@@ -10,7 +10,7 @@ class DefaultCompressor:
     def __init__(self, compressor, typ='text'):
         try:
             self.compressor = import_module(compressor)
-        except ImportError:
+        except ModuleNotFoundError:
             raise RuntimeError("Unsupported compressor")
         self.type = typ
     def get_compressed_len(self, x):


### PR DESCRIPTION
Let the example adapt to any compression algorithm (that conforms to spec) by importing the module under an exception handler.

Example using zstd, which is not found in the original compressors.py 
```
root@b06f53bafe18:/workspace# python main_text.py --compressor gzip
400
400
KNN with compressor=gzip
400it [00:07, 50.78it/s]
Accuracy is 0.6875
spent: 7.89499568939209
root@b06f53bafe18:/workspace# python main_text.py --compressor zstd
400
400
KNN with compressor=zstd
400it [00:02, 172.99it/s]
Accuracy is 0.7375
spent: 2.3285083770751953
```
