### PR TITLE
Fix syntax errors from merges

### DIFF
--- a/compressors.py
+++ b/compressors.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 import torch.nn.functional as F
 import io
 
+
 class DefaultCompressor:
     """for non-neural-based compressor"""
     def __init__(self, compressor, typ='text'):
@@ -28,6 +29,13 @@ class DefaultCompressor:
         """
         Returns the compressed size of the original function
         in bits.
+
+        """
+        with open(original_fn) as fo:
+            data = fo.read()
+            compressed_str = self.compressor.compress(data.encode("utf-8"))
+            return len(compressed_str) * 8 / len(data)
+
 
 """Test Compressors"""
 if __name__ == '__main__':

--- a/data.py
+++ b/data.py
@@ -313,15 +313,14 @@ def load_swahili() -> tuple:
 
 
 def load_filipino():
-    """deprecated - datasets on huggingface have overlapped train&test"""
-    def process(ds):
     """
+    deprecated - datasets on huggingface have overlapped train&test
+
     Loads the Dengue Filipino dataset
 
     Returns:
         tuple: Tuple of lists containing the training and testing datasets respectively.
     """
-
     def process(dataset: list) -> list:
         label_dict = OrderedDict()
         d = {"absent": 0, "dengue": 1, "health": 2, "mosquito": 3, "sick": 4}


### PR DESCRIPTION
Fixes #19
Fixes #20

A couple of recent merges have introduced syntax errors, through what strongly appears to be unintentional omission of some code (#19), and incomplete consolidation of some other code (#20).

This fixes the code in both places. I've taken care to try to address the specific unintended changes that caused breakage. With these fixes applied, all modules are again importable, and running the program as shown in the readme seems to work again.