### PR TITLE
Fix some incorrect type hints and incomplete renames

### DIFF
--- a/compressors.py
+++ b/compressors.py
@@ -1,9 +1,11 @@
 # Compressor Framework
+import io
 import sys
 from importlib import import_module
-from tqdm import tqdm
+
+import numpy as np
 import torch.nn.functional as F
-import io
+from tqdm import tqdm
 
 
 class DefaultCompressor:

--- a/data.py
+++ b/data.py
@@ -2,6 +2,8 @@ import csv
 import os
 import random
 from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -13,8 +15,7 @@ from torch.utils.data import DataLoader, Subset
 
 def _load_csv_filepath(csv_filepath: str) -> list:
     """
-    Loads three elements from a csv file and appends
-    them to a list.
+    Loads three elements from a csv file and appends them to a list.
 
     Arguments:
         csv_filepath (str): Filepath to .csv file.
@@ -24,28 +25,27 @@ def _load_csv_filepath(csv_filepath: str) -> list:
     """
 
     data = []
-    with open(fn, "r") as f:
-        reader = csv.reader(f, delimiter=",", quotechar='"')
+    with open(csv_filepath, "r") as file:
+        reader = csv.reader(file, delimiter=",", quotechar='"')
         for row in reader:
             data.append([row[0], row[1], row[2]])
     return data
 
 
-def read_fn_label(fn: str) -> dict:
+def read_fn_label(filename: str) -> dict:
     """
-    Reads `fn` and returns the a dictionary
-    containing the title+description: label
-    pair.
+    Reads a csv file and returns a dictionary containing
+    title+description: label pairs.
 
     Arguments:
-        fn (str): Filepath to a csv file containing label, title, description.
+        filename (str): Filepath to a csv file containing label, title, description.
 
     Returns:
         dict: {title. description: label} pairings.
     """
 
     text2label = {}
-    data = _load_csv_filepath(fn)
+    data = _load_csv_filepath(filename)
     for row in data:
         label, title, desc = row[0], row[1], row[2]
         text = ". ".join([title, desc])
@@ -54,39 +54,39 @@ def read_fn_label(fn: str) -> dict:
     return text2label
 
 
-def read_label(fn: str) -> list:
+def read_label(filename: str) -> list:
     """
-    Reads the first item from the `fn` csv filepath in each row.
+    Reads the first item from the `filename` csv filepath in each row.
 
     Arguments:
-        fn (str): Filepath to a csv file containing label, title, description.
+        filename (str): Filepath to a csv file containing label, title, description.
 
     Returns:
         list: Labels from the `fn` filepath.
     """
 
-    labels = [row[0] for row in _load_csv_filepath(fn)]
+    labels = [row[0] for row in _load_csv_filepath(filename)]
     return labels
 
 
-def read_fn_compress(fn: str) -> list:
+def read_fn_compress(filename: str) -> list:
     """
     Opens a compressed file and returns the contents
     and delimits the contents on new lines.
 
     Arguments:
-        fn (str): Filepath to a compressed file.
+        filename (str): Filepath to a compressed file.
 
     Returns:
         list: Compressed file contents line separated.
     """
 
-    text = unidecode.unidecode(open(fn).read())
+    text = unidecode.unidecode(open(filename).read())
     text_list = text.strip().split("\n")
     return text_list
 
 
-def read_torch_text_labels(dataset: list, indices: list):
+def read_torch_text_labels(dataset: list, indices: Sequence[int]) -> tuple:
     """
     Extracts the text and labels lists from a pytorch
     `dataset` on `indices`.
@@ -97,7 +97,7 @@ def read_torch_text_labels(dataset: list, indices: list):
                          labels on from `dataset`.
 
     Returns:
-        [list, list]: Text and Label pairs from `dataset` on `indices`.
+        (list, list): Text and Label pairs from `dataset` on `indices`.
 
     """
     text_list = []
@@ -117,7 +117,7 @@ def read_torch_text_labels(dataset: list, indices: list):
     return text_list, label_list
 
 
-def load_20news():
+def load_20news() -> tuple:
     """
     Loads the 20NewsGroups dataset from `torchtext`.
 
@@ -143,9 +143,8 @@ def load_20news():
 
 def load_ohsumed_single(local_directory: str) -> tuple:
     """
-    Loads the Ohsumed dataset from `local_directory`
-    assumes the existence of subdirectories `training`
-    and `test`.
+    Loads the Ohsumed dataset from `local_directory`.
+    Assumes the existence of subdirectories `training` and `test`.
 
     :ref: https://paperswithcode.com/dataset/ohsumed
 
@@ -249,8 +248,8 @@ def load_trec(data_directory: str) -> tuple:
 
     def process(filename: str) -> list:
         processed_data = []
-        with open(fn, encoding="ISO-8859-1") as fo:
-            reader = csv.reader(fo, delimiter=":")
+        with open(filename, encoding="ISO-8859-1") as file:
+            reader = csv.reader(file, delimiter=":")
             for row in reader:
                 label, text = row[0], row[1]
                 processed_data.append((label, text))
@@ -264,9 +263,10 @@ def load_trec(data_directory: str) -> tuple:
 
 def load_kinnews_kirnews(
     dataset_name: str = "kinnews_kirnews", data_split: str = "kinnews_cleaned"
-):
+) -> tuple:
     """
     Loads the KINNEWS and KIRNEWS datasets.
+
     :ref: https://huggingface.co/datasets/kinnews_kirnews
 
     Arguments:
@@ -277,9 +277,9 @@ def load_kinnews_kirnews(
         tuple: Tuple of lists containing the training and testing datasets respectively.
     """
 
-    def process(data_directory: str):
+    def process(dataset: Iterable) -> list:
         pairs = []
-        for pair in data_directory:
+        for pair in dataset:
             label = pair["label"]
             title = pair["title"]
             content = pair["content"]
@@ -299,7 +299,7 @@ def load_swahili() -> tuple:
         tuple: Tuple of lists containing the training and testing datasets respectively.
     """
 
-    def process(dataset: list) -> list:
+    def process(dataset: Iterable) -> list:
         pairs = []
         for pair in dataset:
             label = pair["label"]
@@ -312,7 +312,7 @@ def load_swahili() -> tuple:
     return train_ds, test_ds
 
 
-def load_filipino():
+def load_filipino() -> tuple:
     """
     deprecated - datasets on huggingface have overlapped train&test
 
@@ -321,7 +321,7 @@ def load_filipino():
     Returns:
         tuple: Tuple of lists containing the training and testing datasets respectively.
     """
-    def process(dataset: list) -> list:
+    def process(dataset: Iterable) -> list:
         label_dict = OrderedDict()
         d = {"absent": 0, "dengue": 1, "health": 2, "mosquito": 3, "sick": 4}
         for k, v in d.items():
@@ -341,7 +341,7 @@ def load_filipino():
     return train_ds, test_ds
 
 
-def read_img_with_label(dataset: list, indices: list, flatten=True):
+def read_img_with_label(dataset: list, indices: Sequence[int], flatten: bool = True) -> tuple:
     """
     Loads items from `dataset` based on the indices listed in `indices`
     and optionally flattens them.
@@ -368,7 +368,7 @@ def read_img_with_label(dataset: list, indices: list, flatten=True):
     return np.array(imgs), np.array(labels)
 
 
-def read_img_label(dataset: list, indices: list) -> list:
+def read_img_label(dataset: list, indices: Sequence[int]) -> list:
     """
     Given an image dataset and a list of indices,
     this function returns the labels from the dataset.
@@ -390,7 +390,7 @@ def read_img_label(dataset: list, indices: list) -> list:
 
 def pick_n_sample_from_each_class(
     filename: str, n_samples: int, idx_only: bool = False
-) -> tuple:
+) -> Union[list, tuple]:
     """
     Grabs a random sample of size `n_samples` for each label from the csv file
     at `filename`.
@@ -437,14 +437,17 @@ def pick_n_sample_from_each_class(
 
 
 def pick_n_sample_from_each_class_given_dataset(
-    dataset: list, n_samples: int, output_filename: str = None, index_only: bool = False
+    dataset: Iterable,
+    n_samples: int,
+    output_filename: Optional[str] = None,
+    index_only: bool = False,
 ) -> tuple:
     """
     Grabs a random sample of size `n_samples` for each label from the dataset
     `dataset`.
 
     Arguments:
-        dataset (list): Relative path to the file you want to load.
+        dataset (Iterable): Labeled data, in ``label, text`` pairs.
         n_samples (int): Number of samples to load and return for each label.
         output_filename (str): [Optional] Where to save the recorded indices.
         index_only (bool): True if you only want to return the indices of the rows
@@ -526,15 +529,16 @@ def pick_n_sample_from_each_class_img(
     return result, labels, recorded_idx
 
 
-def load_custom_dataset(di, delimiter='\t'):
-    def process(fn):
-        l = []
-        text_list = open(fn).read().strip().split('\n')
+def load_custom_dataset(directory: str, delimiter: str = "\t") -> tuple:
+    def process(filename: str) -> list:
+        pairs = []
+        text_list = open(filename).read().strip().split("\n")
         for t in text_list:
             label, text = t.split(delimiter)
-            l.append((label,text))
-        return l
-    test_fn = os.path.join(di, 'test.txt')
-    train_fn = os.path.join(di, 'train.txt')
+            pairs.append((label, text))
+        return pairs
+
+    test_fn = os.path.join(directory, "test.txt")
+    train_fn = os.path.join(directory, "train.txt")
     train_ds, test_ds = process(train_fn), process(test_fn)
     return train_ds, test_ds

--- a/experiments.py
+++ b/experiments.py
@@ -9,23 +9,29 @@ from copy import deepcopy
 from functools import partial
 from itertools import repeat
 from statistics import mode
+from typing import Any, Callable, Optional
 
 import numpy as np
 import torch
 from sklearn.metrics.cluster import adjusted_rand_score, normalized_mutual_info_score
 from tqdm import tqdm
 
-from typing import Callable
 from compressors import DefaultCompressor
 
+
 class KnnExpText:
-    def __init__(self, aggregation_function: Callable, compressor: DefaultCompressor, distance_function: Callable):
+    def __init__(
+        self,
+        aggregation_function: Callable,
+        compressor: DefaultCompressor,
+        distance_function: Callable,
+    ) -> None:
         self.aggregation_func = aggregation_function
         self.compressor = compressor
         self.distance_func = distance_function
-        self.distance_matrix = []
+        self.distance_matrix: list = []
 
-    def calc_dis(self, data: list, train_data: list = None, fast: bool = False) -> None:
+    def calc_dis(self, data: list, train_data: Optional[list] = None, fast: bool = False) -> None:
         """
         Calculates the distance between either `data` and itself or `data` and `train_data`
         and appends the distance to `self.distance_matrix`.
@@ -67,7 +73,7 @@ class KnnExpText:
             self.distance_matrix.append(distance4i)
 
     def calc_dis_with_single_compressed_given(
-        self, data: list, data_len: list = None, train_data: list = None
+        self, data: list, data_len: list = None, train_data: Optional[list] = None
     ) -> None:
         """
         Calculates the distance between either `data`, `data_len`, or `train_data`
@@ -81,7 +87,7 @@ class KnnExpText:
         Returns:
             None: None
         """
-        
+
         data_to_compare = data
         if train_data is not None:
             data_to_compare = train_data
@@ -106,7 +112,7 @@ class KnnExpText:
 
     def calc_dis_single(self, t1: str, t2: str) -> float:
         """
-        Calculates the distance between `t1` and `t2` and returns 
+        Calculates the distance between `t1` and `t2` and returns
         that distance value as a float-like object.
 
         Arguments:
@@ -127,7 +133,7 @@ class KnnExpText:
 
     def calc_dis_single_multi(self, train_data: list, datum: str) -> list:
         """
-        Calculates the distance between `train_data` and `datum` and returns 
+        Calculates the distance between `train_data` and `datum` and returns
         that distance value as a float-like object.
 
         Arguments:
@@ -149,9 +155,9 @@ class KnnExpText:
             distance4i.append(distance)
         return distance4i
 
-    def calc_dis_with_vector(self, data: list, train_data: list = None):
+    def calc_dis_with_vector(self, data: list, train_data: Optional[list] = None):
         """
-        Calculates the distance between `train_data` and `data` and returns 
+        Calculates the distance between `train_data` and `data` and returns
         that distance value as a float-like object.
 
         Arguments:
@@ -174,20 +180,25 @@ class KnnExpText:
             self.distance_matrix.append(distance4i)
 
     def calc_acc(
-        self, k: int, label: str, train_label: str = None, provided_distance_matrix: list = None, rand: bool = False
+        self,
+        k: int,
+        label: list,
+        train_label: Optional[list] = None,
+        provided_distance_matrix: Optional[list] = None,
+        rand: bool = False,
     ) -> tuple:
         """
         Calculates the accuracy of the algorithm.
 
         Arguments:
             k (int?): TODO
-            label (str): Predicted Label.
-            train_label (str): Correct Label.
+            label (list): Predicted Labels.
+            train_label (list): Correct Labels.
             provided_distance_matrix (list): Calculated Distance Matrix to use instead of `self.distance_matrix`.
             rand (bool): TODO
 
         Returns:
-            tuple: predictions, and list of bools indicating prediction correctness. 
+            tuple: predictions, and list of bools indicating prediction correctness.
 
         """
         if provided_distance_matrix is not None:
@@ -233,7 +244,14 @@ class KnnExpText:
         print("Accuracy is {}".format(sum(correct) / len(correct)))
         return pred, correct
 
-    def combine_dis_acc(self, k: int, data: list, label: str, train_data: list = None, train_label: str = None) -> tuple:
+    def combine_dis_acc(
+        self,
+        k: int,
+        data: list,
+        label: list,
+        train_data: Optional[list] = None,
+        train_label: Optional[list] = None,
+    ) -> tuple:
         correct = []
         pred = []
         if train_label is not None:
@@ -272,7 +290,14 @@ class KnnExpText:
         print("Accuracy is {}".format(sum(correct) / len(correct)))
         return pred, correct
 
-    def combine_dis_acc_single(self, k: int, train_data: list, train_label: str, datum: list, label: str):
+    def combine_dis_acc_single(
+        self,
+        k: int,
+        train_data: list,
+        train_label: list,
+        datum: str,
+        label: Any,  # int, as used in this application
+    ) -> tuple:
         # Support multi processing - must provide train data and train label
         distance4i = self.calc_dis_single_multi(train_data, datum)
         sorted_idx = np.argpartition(np.array(distance4i), range(k))

--- a/main_text.py
+++ b/main_text.py
@@ -83,7 +83,7 @@ def record_distance(
         del distance_for_selected_test
     else:
         knn_exp.calc_dis(test_data, train_data=train_data)
-        np.save(out_fn, np.array(knn_exp.dis_matrix))
+        np.save(out_fn, np.array(knn_exp.distance_matrix))
     print("spent: {}".format(time.time() - start))
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import numpy as np
 import scipy
 import torch
@@ -27,11 +29,11 @@ def CDM(c1: float, c2: float, c12: float) -> float:
     return dis
 
 
-def MSE(v1: float, v2: float) ->float:
+def MSE(v1: np.ndarray, v2: np.ndarray) -> float:
     """
     Calculates Mean Squared Error.
     """
-    
+
     return np.sum((v1 - v2) ** 2) / len(v1)
 
 
@@ -59,7 +61,7 @@ def agg_by_jag_word(t1: str, t2: str) -> str:
         t2 (str): Second item.
 
     Returns:
-        str: 
+        str:
     """
 
     t1_list = t1.split(" ")
@@ -85,7 +87,7 @@ def agg_by_jag_char(t1: str, t2: str):
         t2 (str): Second item.
 
     Returns:
-        str: 
+        str:
     """
 
     t1_list = list(t1)
@@ -109,7 +111,7 @@ def aggregate_strings(stringa: str, stringb: str, by_character: bool = False) ->
         stringa (str): First item.
         stringb (str): Second item.
         by_character (bool): True if you want to join the combined string by character,
-                             Else combines by word 
+                             Else combines by word
 
     Returns:
         str: combination of stringa and stringb
@@ -129,77 +131,82 @@ def aggregate_strings(stringa: str, stringb: str, by_character: bool = False) ->
         return "".join(combined)
     return " ".join(combined)
 
-def agg_by_avg(i1: list, i2: list) -> torch.Tensor:
+
+def agg_by_avg(i1: torch.Tensor, i2: torch.Tensor) -> torch.Tensor:
     """
-    Calculates the average of i1 and i2 rounding to the
-    shortest list.
+    Calculates the average of i1 and i2, rounding to the shortest.
 
     Arguments:
-        i1 (list): List 1.
-        i2 (list): List 2.
-    
+        i1 (torch.Tensor): First series of numbers.
+        i2 (torch.Tensor): Second series of numbers.
+
     Returns:
-        torch.Tensor: Average of the two lists.
+        torch.Tensor: Average of the two series of numbers.
     """
 
     return torch.div(i1 + i2, 2, rounding_mode="trunc")
 
 
-def agg_by_min_or_max(i1: list, i2: list, aggregate_by_minimum: bool = False) -> torch.Tensor:
+def agg_by_min_or_max(
+    i1: torch.Tensor,
+    i2: torch.Tensor,
+    aggregate_by_minimum: bool = False,
+) -> torch.Tensor:
     """
-    Calculates the average of i1 and i2 rounding to the
-    shortest list.
+    Calculates the average of i1 and i2, rounding to the shortest.
 
     Arguments:
-        i1 (list): List 1.
-        i2 (list): List 2.
-        aggregate_by_minimum (bool): True if you want to take the minimum of the two lists.
+        i1 (torch.Tensor): First series of numbers.
+        i2 (torch.Tensor): Second series of numbers.
+        aggregate_by_minimum (bool): True if you want to take the minimum of the two series.
                                      False if you want to take the maximum instead.
-    
+
     Returns:
-        torch.Tensor: Average of the two lists.
+        torch.Tensor: Average of the two series.
     """
-    
+
     stacked = torch.stack([i1, i2], axis=0)
     if aggregate_by_minimum:
         return torch.min(stacked, axis=0)[0]
-    
+
     return torch.max(stacked, axis=0)[0]
 
 
-def agg_by_stack(i1: list, i2: list) -> torch.Tensor:
+def agg_by_stack(i1: torch.Tensor, i2: torch.Tensor) -> torch.Tensor:
     """
     Combines `i1` and `i2` via `torch.stack`.
-    
+
     Arguments:
-        i1 (list): List 1.
-        i2 (list): List 2.
-    
+        i1 (torch.Tensor): First series of numbers.
+        i2 (torch.Tensor): Second series of numbers.
+
     Returns:
-        torch.Tensor: Stack of the two lists.
+        torch.Tensor: Stack of the two series.
     """
-    
+
     return torch.stack([i1, i2])
 
 
-def mean_confidence_interval(data: list, confidence: float = 0.95) -> tuple:
+def mean_confidence_interval(data: Sequence, confidence: float = 0.95) -> tuple:
     """
     Computes the mean confidence interval of `data` with `confidence`
-    
+
     Arguments:
-        data (list): List of data to compute a confidence interval over.
+        data (Sequence): Data to compute a confidence interval over.
         confidence (float): Level to compute confidence.
 
     Returns:
         tuple: (Mean, quantile-error-size)
     """
 
-    if isinstance(data, list):
-        data = np.array(data, dtype=np.float32)
+    if isinstance(data, np.ndarray):
+        array = data
+    else:
+        array = np.array(data, dtype=np.float32)
 
-    n = data.shape[0]
+    n = array.shape[0]
 
-    mean = np.mean(data)
-    standard_error = scipy.stats.sem(data)
+    mean = np.mean(array)
+    standard_error = scipy.stats.sem(array)
     quantile = scipy.stats.t.ppf((1 + confidence) / 2.0, n - 1)
     return mean, standard_error * quantile


### PR DESCRIPTION
Important changes:

- A number of the type hints on function/method parameters were incorrect (producing errors detected statically by [`mypy`](https://www.mypy-lang.org/), or by temporarily instrumenting the code at runtime with [`typeguard`](https://pypi.org/project/typeguard/)). This fixes most of those.

- A few names of attributes and function parameters were renamed in one place but not another. The affected function parameters, which were mostly on local helper functions, were unintentionally unused, while their old now-unbound names were still referenced. This went undetected because it was on code paths that weren't often exercised. This fixes most (maybe all) cases of that.

More minor changes (only made in code already being changed):

- This adds a few more type hints in places where it is simple to do so and improves consistency, and in some places where type checkers like `mypy` consider it an error for them to be absent.

- In some cases, the incorrect type annotations or incomplete renames appear to have arisen in part due to parameter names with non-obvious meanings, or that vary in meaning across code that otherwise appeared similar. In places where it looks like that was the case, this renames them accordingly.

To keep this PR reasonably scoped, it focuses mainly on fixing bugs. So:

- I have deliberately ***not*** added type annotations to code that does not have them (except for code nearby and closely related, as summaried above).

- I have ***not*** attempted to make the type hints as narrow as possible. Although I have sometimes turned an `X` into an `Optional[X]` (because [PEP 484](https://peps.python.org/pep-0484/) prohibits implicit optional, and type checkers treat it as an error), and used the type `Sequence[int]` in a few places (formerly annotated with `list`, where `range` must also be accepted), this PR otherwise makes no use of type arguments (types that bind to a type variable in a generic type). Although I think such a change may be beneficial (for example, many functions could return types of the form `Tuple[X, Y]` instead of `tuple`), I regard it as both less important than the changes here and outside the reasonable scope of this pull request.

- I have ***not*** attempted to fix every possible type error. Some `mypy` warnings that I believe were correct did not have clear fixes, and I didn't want the rest of these changes to be held back indefinitely. I *have* tried to make sure I was not introducing any new `mypy` warnings.