### PR TITLE
Split CI jobs into more steps for clearer output

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  
+
   publish:
 
     runs-on: ubuntu-latest
@@ -14,23 +14,26 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          poetry --version
+        run: curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Show Poetry version
+        run: poetry --version
+
+      - name: Install project and dependencies
+        run: poetry install
 
       - name: Run Tests
-        run: |
-          poetry install
-          poetry run pytest --junit-xml=junit/test-results-${{ matrix.python-version }}.xml
-          
+        run: poetry run pytest --junit-xml=junit/test-results-${{ matrix.python-version }}.xml
+
       - name: Upload pytest test results
         if: ${{ !cancelled() }}  # Upload results even if tests fail.
         uses: actions/upload-artifact@v3
@@ -38,7 +41,8 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
 
-      - name: Poetry Build & Publish
-        run: |
-          poetry build
-          poetry publish
+      - name: Build Package
+        run: poetry build
+
+      - name: Publish Package
+        run: poetry publish

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -3,7 +3,7 @@ name: Run npc_gzip tests
 on: [push, pull_request]
 
 jobs:
-  
+
   run-tests:
 
     runs-on: ubuntu-latest
@@ -12,24 +12,27 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          poetry --version
+        run: curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Show Poetry version
+        run: poetry --version
+
+      - name: Install project and dependencies
+        run: poetry install
 
       - name: Run Tests
-        run: |
-          poetry install
-          poetry run pytest --junit-xml=junit/test-results-${{ matrix.python-version }}.xml
+        run: poetry run pytest --junit-xml=junit/test-results-${{ matrix.python-version }}.xml
 
-      - name: Upload pytest test results  
+      - name: Upload pytest test results
         if: ${{ !cancelled() }}  # Upload results even if tests fail.
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,12 +5,10 @@ on: [push, pull_request]
 jobs:
 
   run-tests:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This leaves the logic and sequence of operations on CI the same, but makes them more granular so that it is easier to understand their output in the GitHub web interface.

The main benefit is from splitting the old "Run Tests" step into an "Install project and dependencies" step followed by a "Run Tests" step. I noticed that having them together made it hard to read the `pytest` output because it was necessary to scroll down past copious `poetry install` output to find it, instead of just expanding a step. Having "Install project and its dependencies" be its own step before "Run Tests" fixes this, so that expanding "Run Tests" shows all, and only, the actual test output:

> ![Screenshot of workflow output on the Actions tab, showing a test job, with the more narrowly defined Run Tests step expanded and showing readable pytest output, with surrounding steps collapsed non-distractingly](https://github.com/bazingagin/npc_gzip/assets/1771172/4e4f4250-17b4-4ce5-a05e-33424742ed31)

This allows the CI output itself to be as readily usable as the output of running "pytest" interactively. (Of course, the uploaded artifacts are still useful; this does not stop generating those.)

This has a secondary benefit of greater descriptive accuracy. For example, when looking for where we install dependencies, someone unfamiliar with the workflows would not necessarily know to look in "Run Tests".