### PR TITLE
Run black and isort checks on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint Python code
+
+on: [push, pull_request]
+
+jobs:
+
+  black:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Run black
+        uses: psf/black@stable
+
+  isort:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Run isort
+        uses: isort/isort-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,7 @@ on: [push, pull_request]
 jobs:
 
   black:
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -21,9 +19,7 @@ jobs:
         uses: psf/black@stable
 
   isort:
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore original_codebase/ --ignore examples/"
+
+[tool.isort]
+atomic = true
+include_trailing_comma = true
+line_length = 88  # Match behavior of black.
+multi_line_output = 3  # Vertical hanging indent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,3 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore original_codebase/ --ignore examples/"
-
-[tool.black]
-line-length = 87  # FIXME: Remove after testing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore original_codebase/ --ignore examples/"
+
+[tool.black]
+line-length = 87  # FIXME: Remove after testing.


### PR DESCRIPTION
This makes two related changes:

- Configures `isort` to enforce the style of sorting and formatting imports that is already used consistently in this project. It is one of the very good styles, but it is not the default style for `isort`.
- Adds a linting CI workflow that runs `black` and `isort` in check-only mode, to report style violations. Since `isort` is configured, this avoids false positives.

I deliberately produced false positives to ensure that the jobs would actually fail, and give readable output, when they do find style violations. That is the reason for the ordering of my commits and for my deliberate temporary introduction of an unsuitable `black` configuration (since removed, of course).

Some design decisions, and drawbacks, are discussed below.

### No check annotations

Although it's important that the CI checks fail when `black` or `isort` find problems, it would be nice if they could also produce [check annotations](https://github.blog/2018-12-14-introducing-check-runs-and-annotations/) to comment about the problems, much as a human might comment on a pull request during a review. Unfortunately, this does not provide that. I don't know how to do that properly from `isort` or `black` output, with these particular GitHub Actions or otherwise, and they do not do it automatically.

It seem to me that, even without that, this provides value. In particular, this makes it no longer necessary to remember to run the style checkers locally (in the same sense that it is not necessary to remember to run the unit tests locally). Even so--and even if this pull request is, as I propose, merged without that functionality--perhaps we can add it later.

### No project dependency installation

Even though style checkers mostly only need to be able to parse Python syntax, it can sometimes help for them to have the project dependencies installed. This is particularly the case with `isort`, where in obscure situations it may guess wrong about what kind of import something is and whether it is placed in the proper group, if the project's dependencies are not installed. I have nonetheless deliberately not installed the project or its dependencies in either of these jobs.

Avoiding this makes the jobs' code much shorter and simpler in the workflow file, which is really not that important, but it also makes them run *much* faster, which I think is worth it, at least for starters. (Note that only affects `isort` on CI, where it is never *modifying* code.) Nonetheless, I'd be pleased to change that, or other aspects of these workflows, on request.