### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
 {
     "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
-    "features": {
-        "ghcr.io/devcontainers-contrib/features/poetry:2": {}
-    },
     "customizations": {
         "vscode": {
             "extensions": [
@@ -21,5 +18,6 @@
                 "gitlens.showWhatsNewAfterUpgrades": false
             }
         }
-    }
+    },
+    "onCreateCommand": [".devcontainer/onCreate"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bierner.markdown-preview-github-styles",
+                "eamodio.gitlens",
+                "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
+                "mhutchie.git-graph",
+                "ms-python.isort",
+                "ms-python.python",
+                "ms-toolsai.jupyter",
+                "tamasfe.even-better-toml"
+            ],
+            "settings": {
+                "gitlens.showWelcomeOnInstall": false,
+                "gitlens.showWhatsNewAfterUpgrades": false
+            }
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,11 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "bierner.markdown-preview-github-styles",
                 "eamodio.gitlens",
-                "GitHub.vscode-github-actions",
                 "GitHub.vscode-pull-request-github",
                 "mhutchie.git-graph",
                 "ms-python.isort",
                 "ms-python.python",
-                "ms-toolsai.jupyter",
                 "tamasfe.even-better-toml"
             ],
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
     "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+    "features": {
+        "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -8,3 +8,7 @@ pipx inject poetry poetry-plugin-sort poetry-plugin-up
 
 # Set up project environment for poetry.
 poetry install
+
+# Modify the project environment so it can run all examples with no GPU.
+poetry run pip install -U pip setuptools wheel
+poetry run pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+# Set up Poetry and its plugins.
+pipx install poetry
+pipx inject poetry poetry-plugin-sort poetry-plugin-up
+
+# Set up project environment for poetry.
+poetry install


### PR DESCRIPTION
This adds a [dev container](https://containers.dev/) configuration for trying out or working on this project in a [**codespace**](https://github.com/features/codespaces) or [local dev container](https://code.visualstudio.com/docs/devcontainers/containers). The default dev container configuration using the universal image does not support this project well.

<details><summary>Why the default config doesn't support this project (click to expand if interested)</summary>
<blockquote>
<p>Not every project requires such a configuration to be usable in a dev container. When no <code>devcontainer.json</code> file is present, a <a href="https://github.com/devcontainers/images/tree/main/src/universal">universal image</a> is used, which is a large image with tools for <a href="https://mcr.microsoft.com/en-us/product/devcontainers/universal/about">many languages and frameworks</a>. Furthermore, it can be better to use the universal image than a custom image, if the custom image would have a longer startup time, as is often the case.</p>
<p>Unfortunately, the universal image is unsuitable for working on this project because the Python implementation it ships is built without <code>lzma</code> support. <code>npc-gzip</code> can be used <em>as a library</em> where <code>lzma</code> support is absent, so long as it is not needed. But it is needed for some unit tests to pass (as well as to actually do anything with the <code>lzma</code> compressor). Furthermore, because users often use a codespace to get a feel for a project, all of a project&#39;s core functionality should be usable in a dev container, where feasible. The lack of <code>lzma</code> support was helpful when reviewing #30 because it allowed me to verify that the error-handling logic for that condition was working, but for any other goal it is a disadvantage.</p>
<p>Another reason this project benefits from a custom <code>devcontainer.json</code> is that the most popular way to use dev containers is in GitHub Codespaces with small codespaces not offering GPU access. Nothing in this project requires a GPU--that&#39;s one of the benefits of the technique presented in the paper and implemented in this codebase--but the modules in <code>examples</code> use PyTorch. On GNU/Linux systems, installing <code>torch</code> from PyPI provides a build that expects CUDA libraries to be installed and raises <code>ImportError</code> when they are absent. One of the goals of dev containers is to be able to get up and running with minimal effort, and providing a custom <code>devcontainer.json</code> enables a workaround for this issue to be applied.</p>
</blockquote>
</details>

This adds a custom `devcontainer.json` using the Debian 12 based Python 3.11 image, which is one of the [prebuilt Python images](https://github.com/devcontainers/images/tree/main/src/python). Unlike the universal image, `python` in that image is built with `lzma` support, and all tests are able to run and pass. I also included a script run on dev container creation that takes care of installing `poetry` with useful plugins, using it to install the project, and modifying the resulting environment with a compatible `torch` package so that the code in `examples` can also be imported and run.

This supports using the new codebase, including the examples, with minimal effort. Although it would be useful for the dev container to also support using the old codebase with minimal effort, this does not attempt that, because:

- I think it may be better to have a separate selectable dev container configuration for it, especially if its dependencies are to be automatically installed during container creation.
- More importantly, installing the `torch` dependency--for `old_codebase`, not for the new code--uses more RAM than a default codespace provides. (I found that out when testing locally while limiting memory usage, and also on [a separate branch](https://github.com/EliahKagan/npc_gzip/pull/2) with a 3.10 container, since the old codebase `requirements.txt` is not compatible with 3.11.)