### PR TITLE
Remove unused imports

### DIFF
--- a/examples/ag_news.py
+++ b/examples/ag_news.py
@@ -1,6 +1,5 @@
 import numpy as np
 from sklearn.metrics import classification_report
-from sklearn.utils import shuffle
 from torchtext.datasets import AG_NEWS
 
 from npc_gzip.compressors.base import BaseCompressor

--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -1,6 +1,5 @@
 import numpy as np
 from sklearn.metrics import classification_report
-from sklearn.utils import shuffle
 from torchtext.datasets import IMDB
 
 from npc_gzip.compressors.base import BaseCompressor

--- a/npc_gzip/aggregations.py
+++ b/npc_gzip/aggregations.py
@@ -1,7 +1,5 @@
 import itertools
 
-import numpy as np
-
 
 def concatenate_with_space(stringa: str, stringb: str) -> str:
     """

--- a/npc_gzip/distance.py
+++ b/npc_gzip/distance.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from typing import Sequence
 
 import numpy as np
 

--- a/npc_gzip/knn_classifier.py
+++ b/npc_gzip/knn_classifier.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 import numpy as np
 from tqdm import tqdm
@@ -86,10 +86,10 @@ class KnnClassifier:
         assert (
             self.training_inputs.shape == self.training_labels.shape
         ), f"""
-        Training Inputs and Labels did not maintain their 
+        Training Inputs and Labels did not maintain their
         shape during the conversion from lists to numpy arrays.
         This is most likely a bug in the numpy package:
-        
+
         self.training_inputs.shape: {self.training_inputs.shape}
         self.training_labels.shape: {self.training_labels.shape}
         """
@@ -309,9 +309,9 @@ class KnnClassifier:
         assert (
             top_k <= x.shape[0]
         ), f"""
-        top_k ({top_k}) must be less or equal to than the number of 
+        top_k ({top_k}) must be less or equal to than the number of
         samples provided to be predicted on ({x.shape[0]})
-        
+
         """
 
         # sample training inputs and labels

--- a/npc_gzip/utils.py
+++ b/npc_gzip/utils.py
@@ -10,14 +10,12 @@ rest of the codebase.
 import random
 import string
 
-from npc_gzip.exceptions import InvalidObjectTypeException
-
 
 def generate_sentence(number_of_words: int = 10) -> str:
     """
     Generates a sentence of random
-    numbers and letters, with 
-    `number_of_words` words in the 
+    numbers and letters, with
+    `number_of_words` words in the
     sentence such that len(out.split()) \
     == `number_of_words`.
 

--- a/original_codebase/data.py
+++ b/original_codebase/data.py
@@ -1,16 +1,14 @@
 import csv
 import os
 import random
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import Optional, Sequence, Union
 
 import numpy as np
-import torch
 import unidecode
 from datasets import load_dataset
 from sklearn.datasets import fetch_20newsgroups
-from torch.utils.data import DataLoader, Subset
 
 
 def _load_csv_filepath(csv_filepath: str) -> list:

--- a/original_codebase/experiments.py
+++ b/original_codebase/experiments.py
@@ -1,20 +1,11 @@
 # Experiment framework
 import operator
-import os
-import pickle
 import random
-import statistics
-from collections import Counter, defaultdict
-from copy import deepcopy
-from functools import partial
-from itertools import repeat
-from statistics import mode
+from collections import defaultdict
 from typing import Any, Callable, Optional
 
 import numpy as np
-import torch
 from compressors import DefaultCompressor
-from sklearn.metrics.cluster import adjusted_rand_score, normalized_mutual_info_score
 from tqdm import tqdm
 
 

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -1,7 +1,4 @@
-import pytest
-
 from npc_gzip.aggregations import aggregate_strings, concatenate_with_space
-from npc_gzip.exceptions import StringTooShortException
 
 
 class TestAggregations:

--- a/tests/test_base_compressor.py
+++ b/tests/test_base_compressor.py
@@ -1,5 +1,4 @@
 import gzip
-from types import ModuleType
 
 import pytest
 

--- a/tests/test_bz2_compressor.py
+++ b/tests/test_bz2_compressor.py
@@ -1,11 +1,7 @@
 import bz2
-from types import ModuleType
-
-import pytest
 
 from npc_gzip.compressors.base import BaseCompressor
 from npc_gzip.compressors.bz2_compressor import Bz2Compressor
-from npc_gzip.exceptions import InvalidCompressorException
 
 
 class TestBz2Compressor:

--- a/tests/test_gzip_compressor.py
+++ b/tests/test_gzip_compressor.py
@@ -1,11 +1,7 @@
 import gzip
-from types import ModuleType
-
-import pytest
 
 from npc_gzip.compressors.base import BaseCompressor
 from npc_gzip.compressors.gzip_compressor import GZipCompressor
-from npc_gzip.exceptions import InvalidCompressorException
 
 
 class TestBz2Compressor:

--- a/tests/test_knn_classifier.py
+++ b/tests/test_knn_classifier.py
@@ -7,10 +7,8 @@ from npc_gzip.compressors.base import BaseCompressor
 from npc_gzip.compressors.bz2_compressor import Bz2Compressor
 from npc_gzip.compressors.gzip_compressor import GZipCompressor
 from npc_gzip.compressors.lzma_compressor import LzmaCompressor
-from npc_gzip.distance import Distance
 from npc_gzip.exceptions import (
     InputLabelEqualLengthException,
-    InvalidObjectTypeException,
     UnsupportedDistanceMetricException,
 )
 from npc_gzip.knn_classifier import KnnClassifier

--- a/tests/test_lzma_compressor.py
+++ b/tests/test_lzma_compressor.py
@@ -1,11 +1,7 @@
 import lzma
-from types import ModuleType
-
-import pytest
 
 from npc_gzip.compressors.base import BaseCompressor
 from npc_gzip.compressors.lzma_compressor import LzmaCompressor
-from npc_gzip.exceptions import InvalidCompressorException
 
 
 class TestBz2Compressor:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import random
 
 import pytest
 
-from npc_gzip.exceptions import InvalidObjectTypeException
 from npc_gzip.utils import generate_dataset, generate_sentence
 
 


### PR DESCRIPTION
This removes unused imports, both in the current code (`npc_gzip/`, `examples/`, and `tests/`) and in the old code (`original_codebase/`).

Either all or nearly all unused imports are removed, depending on precisely how one defines "unused." I avoided removing imports (or making any changes) where imports are unreferenced but in some other sense used, such that removing them without making other code changes would cause breakage or alter behavior.

<details><summary>Info on "unused" imports that are needed and not removed (click to expand if interested)</summary>
<blockquote>
<p>There are only two such places.</p>
<ul>
<li>In the new code, <code>npc_gzip/__init__.py</code>, has imports but no <code>__all__</code>, so technically those imports are nonpublic, and since no code in that file uses them (there is no other code in that file), they are &quot;unused&quot;. It may be better to avoid <code>*</code> imports and assign <code>__all__</code> in that file, but I would consider such a change outside the scope of this PR.</li>
<li>In the old code, <code>eval(args.dataset)(root=args.data_dir)</code> is used to load datasets dynamically in a way that requires them to have been imported into the module, yet the imports are &quot;unused&quot; in the sense that no code written in the module refers to them. It may be best to have a comment about this, or use <code>importlib</code> instead of an <code>eval</code>-based way, but such changes are not necessarily justified for the original codebase that is not under active development. Even if such changes are made, they, too, are outside the intended scope of this PR.</li>
</ul>
<p>All other unused imports are removed.</p>
</blockquote>
</details>

Although major changes probably shouldn't be made to the original codebase without strong reason, it is clear from context that the unused imports in it are mostly due to other fairly recent changes (some as recent as #30).

I have tested this change, both in the new code by running `pytest` in the `poetry`-managed environment (in Python 3.11, but also CI checks this for 3.9, 3.10, and 3.11), and in the original codebase by installing its dependencies in a Python 3.10 virtual environment and running `python main_text.py` and `python main_text.py --para`.