### PR TITLE
Fix Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,25 @@ This paper is accepted to Findings of [ACL2023](https://aclanthology.org/2023.fi
 
 ## Getting Started
 
-This codebase is [available on pypi.org via](https://pypi.org/project/npc-gzip) 
+This codebase is [available on pypi.org via](https://pypi.org/project/npc-gzip):
 
 
-```bash
-
+```sh
 pip install npc-gzip
-
 ```
 
 ## Usage
 
 See the [examples](./examples/imdb.py) directory for example usage.
 
-
 ## Testing
 
 This package utilizes `poetry` to maintain its dependencies and `pytest` to execute tests. To get started running the tests:
 
-```bash
-
+```sh
 poetry shell
 poetry install
 pytest
-
 ```
 
 -------------------------
@@ -39,7 +34,8 @@ pytest
 See `requirements.txt`.
 
 Install requirements in a clean environment:
-```
+
+```sh
 conda create -n npc python=3.7
 conda activate npc
 pip install -r requirements.txt
@@ -47,12 +43,13 @@ pip install -r requirements.txt
 
 #### Run
 
-```
+```sh
 python main_text.py
 ```
+
 By default, this will only use 100 test and training samples per class as a quick demo. They can be changed by `--num_test`, `--num_train`.
 
-```
+```text
 --compressor <gzip, lzma, bz2>
 --dataset <AG_NEWS, SogouNews, DBpedia, YahooAnswers, 20News, Ohsumed_single, R8, R52, kinnews, kirnews, swahili, filipino> [Note that for small datasets like kinnews, default 100-shot is too big, need to set --num_test and --num_train.]
 --num_train <INT>
@@ -65,16 +62,16 @@ By default, this will only use 100 test and training samples per class as a quic
 --test_idx_end <INT> [These two args help us to run on a certain range of test set. Also helpful for calculating the distance matrix on the whole dataset.]
 --para [This will use multiprocessing to accelerate.]
 --output_dir <DIR> [The output directory to save information of tested indices or distance matrix.]
-
 ```
 
 #### Calculate Accuracy (Optional)
 
-If we want to calculate accuracy from recorded distance file <DISTANCE DIR>, use
+If we want to calculate accuracy from recorded distance file `<DISTANCE DIR>`, use
 
+```sh
+python main_text.py --record --score --distance_fn <DISTANCE DIR>
 ```
-python main_text.py --record --score --distance_fn <DISTANCE DIR> 
-```
+
 to calculate accuracy. Otherwise, the accuracy will be calculated automatically using the command in the last section.
 
 #### Use Custom Dataset
@@ -84,4 +81,3 @@ You can use your own custom dataset by passing `custom` to `--dataset`; pass the
 Both `train.txt` and `test.txt` are expected to have the format `{label}\t{text}` per line.
 
 You can change the delimiter according to you dataset by changing `delimiter` in `load_custom_dataset()` in `data.py`.
-


### PR DESCRIPTION
This fixes some problems with the Markdown in the README file:

- `<DISTANCE DIR>` was written without surrounding backticks, so all renderers simply removed it. This abridged the text of the original "Calculate Accuracy" section in an unintended way.
- Code fences contained leading and trailing blank lines that were not intended to be rendered, but whether such lines produce line breaks in rendered output varies by dialect/renderer. On the GitHub web interface, they're never rendered. On PyPI, one such code fence shows its trailing blank line. In VS Code (including Codespaces), they were rendered in multiple cases.
- Least importantly, languages for code fence syntax highlighting were not always specified. This fixes that (and specifies sh instead of bash for "universal" shell commands).