### PR TITLE
Add CI test jobs for other operating systems

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,14 +32,14 @@ jobs:
         run: poetry install
 
       - name: Run Tests
-        run: poetry run pytest --junit-xml=junit/test-results-3.9.xml
+        run: poetry run pytest --junit-xml=junit/test-results-ubuntu-3.9.xml
 
       - name: Upload pytest test results
         if: ${{ !cancelled() }}  # Upload results even if tests fail.
         uses: actions/upload-artifact@v3
         with:
-          name: pytest-results-3.9
-          path: junit/test-results-3.9.xml
+          name: pytest-results-ubuntu-3.9
+          path: junit/test-results-ubuntu-3.9.xml
 
       - name: Build Package
         run: poetry build

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
 
   run-tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu, macos, windows]
         python-version: ["3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -19,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: curl -sSL https://install.python-poetry.org | python -
 
       - name: Show Poetry version
         run: poetry --version
@@ -28,11 +29,11 @@ jobs:
         run: poetry install
 
       - name: Run Tests
-        run: poetry run pytest --junit-xml=junit/test-results-${{ matrix.python-version }}.xml
+        run: poetry run pytest --junit-xml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
 
       - name: Upload pytest test results
         if: ${{ !cancelled() }}  # Upload results even if tests fail.
         uses: actions/upload-artifact@v3
         with:
-          name: pytest-results-${{ matrix.python-version }}
-          path: junit/test-results-${{ matrix.python-version }}.xml
+          name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python -
+        run: pip install poetry
 
       - name: Show Poetry version
         run: poetry --version


### PR DESCRIPTION
This expands the CI test matrix so that in addition to testing all three Python versions we support on Ubuntu, it also tests them on macOS and on Windows. This expands the number of jobs from three to nine.

I strongly believe it is worthwhile to test on multiple operating systems. However, some new considerations arise when doing so. I am aware of three cases where I made choices that are not obvious and that it may be reasonable to make it a different way:

### Artifact names and the `os` variable

The output artifact names are expanded accordingly, so that they do not clash with each other. A less important corresponding change is also made to the artifact name in the publishing workflow for consistency (just as it already had `3.9` in its name before, for consistency).

It would be more common and idiomatic to have the `os` matrix variable take on full names like `ubuntu-latest` rather than `ubuntu`. However, examining output would be cumbersome if `latest` appeared in all the artifact filenames. Using the shorter names in `os` and specifying the OS as `${{ matrix.os }}-latest` avoids that without extra complexity.

### Poetry installation

This changes how the test workflow installs Poetry, using `pip` instead of the install script.

As detailed in 392c36f, this works on all three OSes, without requiring the workflow to become brittle (e.g., by hard-coding paths) or significantly more complicated, and in a way that decisively avoids accidentally installing and testing the project with the same version of Python in each job (as happens with `pipx` on *Windows* GitHub Actions runners unless one is very careful).

None of these problems applied when we were only testing on Ubuntu, so the publishing workflow does not need to be changed. Installing `poetry` with `pip` is not ideal but I believe these considerations justify it.

### Fail-fast

The default behavior of a GitHub Actions workflow with a matrix strategy is to fail fast: when any generated job fails, the other jobs generated from the same matrix (that were triggered by the same event) are canceled automatically.

I have *kept* this default. Having more jobs is what the default is meant for. CI is rate-limited, and when pushing many commits while code under test is temporarily not working--typically to a feature branch, including in the case of an unfinished PR--it is useful to avoid running extra test jobs. Test jobs are heavier than some other kinds of jobs because they have to install dependencies.

However, it is possible to have a situation that is broken for a specific combination of OS and Python version, where it is useful to see complete test results from the other jobs. It is also possible to make a major change and want to know *everything* it breaks. So failing fast has some disadvantages. But I think, overall, it makes sense. This can always be changed later, of course.