### PR TITLE
Enable CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        setup-python-dependencies: false
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,82 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '45 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners
+    # Consider using larger runners for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This adds a [CodeQL](https://codeql.github.com/) CI workflow, to complement the automated tests and style checkers. It runs the default/recommended CodeQL queries for Python code.

It uses the default triggers for CodeQL: pushes to the main branch, PRs targeting the main branch, and once weekly. It can be broadened to run on all branches even if not on main or a PR targeting main, but CodeQL tends to be slower than most workflows so I think the existing defaults make sense. If it turns out to be fast, we may want to change it later to run on all branches. The reason it also runs on a weekly schedule is that new CodeQL queries are added regularly (which is not the case for most other tools).

The CodeQL developers believe they have [improved CodeQL to the point that it does not need to be able to examine the code of Python dependencies](https://github.blog/changelog/2023-07-12-code-scanning-with-codeql-no-longer-installs-python-dependencies-automatically-for-new-users/) to reliably detect bugs. I have customized this workflow *not* to install dependencies. This saves the time of installing them and also of CodeQL traversing into and examining them. That is the only way I have customized it.

This customization might not be needed. If you, as the repository owner, have not used CodeQL on *any* of your repositories prior to [that announcement](https://github.blog/changelog/2023-07-12-code-scanning-with-codeql-no-longer-installs-python-dependencies-automatically-for-new-users/), I believe it will not install dependencies unless explicitly configured to do so. That is, I believe the default behavior is controlled by factors *outside* the workflow file. However, the explicit `setup-python-dependencies: false` may still be valuable, because it may make CodeQL faster if it is run in forks (whose owners may have been using CodeQL in other repositories before the change).

Even if you decide to enable CodeQL, you don't have to accept this pull request! There are other ways to set it up that you might prefer:

- In the repository settings, you could set up a "Default" CodeQL configuration, which is similar to this and does not require that any workflow file be committed to the repository. I don't know if that will install Python dependencies. It does for me, in some repositories ([here's an example](https://github.com/EliahKagan/subaudit/actions/runs/5442346371/job/14731507765#step:3:248)).
- Also in the repository settings, you could set up an "Advanced" configuration, which includes the scheduled scan. An "Advanced" configuration can be customized; the configuration in this PR is produced that way.

I will not mind at all if you do one of those things and close this pull request instead of accepting it--the main goal of this PR is to propose the use of CodeQL. I also understand you may decide not to use CodeQL at all.