### PR TITLE
Release for bugfix in #37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "npc-gzip"
-version = "0.1.0"
+version = "0.1.1"
 description = "Code for Paper: “Low-Resource” Text Classification: A Parameter-Free Classification Method with Compressors"
 authors = [
     "Gin Jiang <bazingagin@gmail.com>",


### PR DESCRIPTION
This bumps the patch version, for doing an update for a 0.1.1 release on PyPI that includes the change from the fix in #37. I think it is a good idea to do this, due to the importance of the fix as noted in #37, and more generally because it can be more manageable to do more frequent smaller releases rather than accumulating many changes into less frequent bigger releases.

Since we are not yet at 1.0.0, [SemVer](https://semver.org/) doesn't strictly dictate if this should be 0.1.1 or 0.2.0. #37 is arguably a small but breaking change, considering how the tests needed to be changed. But it seems conceptually to be a bugfix.

This can be changed to 0.2.0 if desired. Also, whatever version is used, the bump could instead be done by some means other than this PR. The purpose of this PR is to propose that another release be done on PyPI, but if it turns out to be easier to close this PR and bump the version number in some other way, that's just as good.

I checked available versions of direct and indirect dependencies, which all appear current, so this PR modifies the `version` metadata only.

Note: The first CI run for this PR [failed on one of the test jobs](https://github.com/bazingagin/npc_gzip/actions/runs/5753719296/job/15597516762?pr=43). When re-run, [all jobs succeeded](https://github.com/EliahKagan/npc_gzip/actions/runs/5753657643/job/15597332321). I believe the failure is due to the way the test uses random numbers, as described in #45 with a proposed fix in #46. I don't think it needs to hold back the release (#46 only modifies test code, which isn't included in our PyPI package).