### PR TITLE
Fix test bug where size-1 sample may be used (with top_k=2)

### DIFF
--- a/tests/test_knn_classifier.py
+++ b/tests/test_knn_classifier.py
@@ -116,7 +116,7 @@ class TestKnnClassifier:
         assert labels.shape == (1,)
         assert similar_samples.shape == (top_k, 1)
 
-        test_set_size = random.randint(2, 2)  # FIXME: Put upper bound back to 50.
+        test_set_size = random.randint(2, 50)
         test_set = [self.sample_input for _ in range(test_set_size)]
         top_k = 2
         (distance, labels, similar_samples) = self.model.predict(test_set, top_k)

--- a/tests/test_knn_classifier.py
+++ b/tests/test_knn_classifier.py
@@ -116,7 +116,7 @@ class TestKnnClassifier:
         assert labels.shape == (1,)
         assert similar_samples.shape == (top_k, 1)
 
-        test_set_size = random.randint(1, 50)
+        test_set_size = random.randint(1, 1)  # FIXME: Put upper bound back to 50.
         test_set = [self.sample_input for _ in range(test_set_size)]
         top_k = 2
         (distance, labels, similar_samples) = self.model.predict(test_set, top_k)

--- a/tests/test_knn_classifier.py
+++ b/tests/test_knn_classifier.py
@@ -116,7 +116,7 @@ class TestKnnClassifier:
         assert labels.shape == (1,)
         assert similar_samples.shape == (top_k, 1)
 
-        test_set_size = random.randint(1, 1)  # FIXME: Put upper bound back to 50.
+        test_set_size = random.randint(2, 2)  # FIXME: Put upper bound back to 50.
         test_set = [self.sample_input for _ in range(test_set_size)]
         top_k = 2
         (distance, labels, similar_samples) = self.model.predict(test_set, top_k)


### PR DESCRIPTION
Closes #45

This changes the range of possible sample sizes in `TestKnnClassifier.test_predict` to have a lower bound of `2` instead of `1`, so that the test, which always uses a `top_k` of `2`, no longer occasionally fails.

The change is actually [very simple](https://github.com/bazingagin/npc_gzip/pull/46/files), but I did it in a few commits to verify and show that a lower bound of `1` was the problem. The sample size is being selected randomly, so it would otherwise not be immediately clear that this change really fixes the bug.