### PR TITLE
Fix link to examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install npc-gzip
 
 ## Usage
 
-See the [examples](./examples/imdb.py) directory for example usage.
+See the [examples](./examples/) directory for example usage.
 
 ## Testing
 


### PR DESCRIPTION
When the examples link was added to the readme, there was only one example, so it made sense to link to it directly. Later, a second example was added.

This updates the link so it points to the directory rather than a specific module in it.